### PR TITLE
Fix/search raw url

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -5,13 +5,21 @@ class SearchController < ApplicationController
   before_action :not_logged_in
 
   def index
-    @suchEingabe = params[:search_query]
+    set_such_eingabe
 
     @gefundeneFiles = if !@suchEingabe.empty?
                         UserResource.search(@suchEingabe)
                       else
                         UserResource.all
                       end
+  end
+
+  def set_such_eingabe
+    if !params[:search_query].present?
+      @suchEingabe = ''
+    else
+      @suchEingabe = params[:search_query]
+    end
   end
 
   def not_logged_in


### PR DESCRIPTION
Instead of showing error message, the user can now search for /search or /searchresults and will be shown every file, just like when the user just hits enter in the search bar